### PR TITLE
Add MEDIA BLACKOUT AI orchestration documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,19 @@
 # agent_start
 
-This repository contains an example Orchestration Agent service. The orchestrator
-coordinates multiple specialist agents to achieve high level goals. A small
-FastAPI server exposes endpoints to trigger tasks and monitor progress.
+This repository contains a small orchestration service demonstrating how multiple specialized agents can be coordinated to accomplish complex goals. The project uses FastAPI to expose endpoints for starting new tasks and monitoring progress.
 
-Run the server with:
+## Running the Server
 
 ```bash
 python app.py
 ```
 
-Then POST to `/task` with a JSON body `{"goal": "your goal"}` to start.
+Once running, trigger a task with:
+
+```bash
+curl -X POST http://localhost:8000/task -H 'Content-Type: application/json' -d '{"goal": "your goal"}'
+```
+
+Monitor progress via `GET /status`. Tasks that require confirmation can be approved or denied by POSTing to `/approve`.
+
+See `docs/MEDIA_BLACKOUT_AI.md` for guidance on expanding this prototype into a production‑ready orchestration system for MEDIA BLACKOUT LLC.

--- a/docs/MEDIA_BLACKOUT_AI.md
+++ b/docs/MEDIA_BLACKOUT_AI.md
@@ -1,0 +1,78 @@
+# MEDIA BLACKOUT LLC AI Orchestration Architecture
+
+This document outlines how to expand the basic orchestration service in this repository into a fully functional AI system suitable for coordinating complex tasks across multiple specialized agents. The design leverages the existing `Orchestrator` and agent stubs as a starting point.
+
+## Overview
+
+The orchestrator coordinates a set of agents to accomplish high‑level goals. Each agent encapsulates a domain of expertise, exposing a simple interface (`execute` or `decide`). MEDIA BLACKOUT LLC can extend these agents to cover additional domains such as marketing, infrastructure, finance, and compliance.
+
+```
+Client -> FastAPI server -> Orchestrator -> [agents]
+```
+
+The main workflow is:
+
+1. **Planning** – The orchestrator creates a plan for a given goal, optionally assisted by an LLM.
+2. **Execution** – Each task in the plan is dispatched to the appropriate agent. Tasks can require approval before execution.
+3. **Review** – Results of each task are summarized to determine whether the goal is complete.
+
+## Adding New Agents
+
+Create new Python classes under `agents/` implementing either an `execute` method (for actionable tasks) or a `decide` method (for decision making). Register the agent in `Orchestrator.__init__` by adding it to `self.agents`.
+
+Example skeleton:
+
+```python
+# agents/marketing_agent.py
+class MarketingAgent:
+    """Handles marketing campaigns."""
+
+    def execute(self, task: str) -> str:
+        # Implement domain‑specific work here
+        return f"[MarketingAgent] {task}"
+```
+
+```python
+# orchestrator.py
+from agents.marketing_agent import MarketingAgent
+...
+self.agents = {
+    "marketing": MarketingAgent(),
+    # existing agents
+}
+```
+
+## Deployment
+
+The FastAPI app in `app.py` exposes three endpoints:
+
+- `POST /task` – begin orchestrating a new goal.
+- `GET /status` – retrieve orchestrator state and log messages.
+- `POST /approve` – approve or deny tasks that require confirmation.
+
+Run the service locally with:
+
+```bash
+python app.py
+```
+
+MEDIA BLACKOUT LLC can containerize this service and deploy it to an environment of choice (e.g., AWS ECS or Kubernetes). Agents that interact with cloud resources should handle authentication via environment variables or IAM roles.
+
+## Extending the Planner
+
+The current planner stub returns a fixed list of tasks. To automate more complex planning, integrate a language model:
+
+```python
+import openai
+
+prompt = f"Plan steps to achieve: {goal}."  # customize as needed
+resp = openai.ChatCompletion.create(model="gpt-4", messages=[{"role": "user", "content": prompt}])
+plan_text = resp["choices"][0]["message"]["content"]
+# parse `plan_text` into Task objects
+```
+
+This approach lets MEDIA BLACKOUT LLC dynamically generate plans for novel goals.
+
+## Conclusion
+
+Using the structure in this repository, MEDIA BLACKOUT LLC can develop a suite of cooperating agents managed by the orchestrator to accomplish high‑level objectives. Expand the agents and planning logic to cover the company’s operations, and deploy the FastAPI service to begin coordinating tasks.


### PR DESCRIPTION
## Summary
- expand the README with instructions for running the server and using the API
- add `docs/MEDIA_BLACKOUT_AI.md` describing how MEDIA BLACKOUT LLC can extend the orchestrator with new agents and deployment guidance

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688a9e66125c8321a334b8e06b2305b7