### PR TITLE
Add basic Morpheus orchestration with Redis-backed session and queue

### DIFF
--- a/morpheus.py
+++ b/morpheus.py
@@ -1,0 +1,76 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+from session_manager import SessionManager
+from task_queue import TaskQueue
+import subprocess
+
+
+class NeoAgent:
+    """Very simple planner that delegates directory listings to Trinity."""
+
+    def handle(self, payload, session):
+        text = payload.get("text", "")
+        if "list" in text.lower() or "directory" in text.lower():
+            return {"delegate": "Trinity", "command": "ls"}
+        return {"response": "I only know how to list directories for now."}
+
+
+class TrinityAgent:
+    """Executes shell commands with a tiny allow-list."""
+
+    ALLOW = {"ls"}
+
+    def handle(self, payload, session):
+        cmd = payload.get("command", "")
+        base = cmd.split()[0]
+        if base not in self.ALLOW:
+            return {"status": "error", "output": "Command not allowed."}
+        proc = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+        return {"status": "success", "output": proc.stdout.strip()}
+
+
+class Morpheus:
+    def __init__(self):
+        self.sessions = SessionManager()
+        self.queue = TaskQueue()
+        self.agents = {"Neo": NeoAgent(), "Trinity": TrinityAgent()}
+
+    def handle_message(self, session_id: str, message: str):
+        self.queue.push({"agent": "Neo", "session_id": session_id, "payload": {"text": message}})
+        result = None
+        while True:
+            task = self.queue.pop()
+            if not task:
+                break
+            agent = self.agents[task["agent"]]
+            session = self.sessions.get(task["session_id"])
+            res = agent.handle(task["payload"], session)
+            self.sessions.append(task["session_id"], {task["agent"]: res})
+            if task["agent"] == "Neo" and res.get("delegate"):
+                self.queue.push({
+                    "agent": res["delegate"],
+                    "session_id": task["session_id"],
+                    "payload": {"command": res["command"]},
+                })
+            else:
+                result = res
+        return result
+
+
+morpheus = Morpheus()
+app = FastAPI()
+
+
+class ChatRequest(BaseModel):
+    session_id: str
+    message: str
+
+
+@app.post("/chat")
+def chat(req: ChatRequest):
+    return morpheus.handle_message(req.session_id, req.message)
+
+
+if __name__ == "__main__":
+    output = morpheus.handle_message("demo", "Please list the current directory")
+    print(output)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 openai
 python-dotenv
+fastapi
+redis
+uvicorn

--- a/session_manager.py
+++ b/session_manager.py
@@ -1,0 +1,17 @@
+import json
+import redis
+
+class SessionManager:
+    """Simple Redis-backed session store."""
+
+    def __init__(self, redis_client=None):
+        self.redis = redis_client or redis.Redis(host='localhost', port=6379, decode_responses=True)
+
+    def get(self, session_id: str):
+        data = self.redis.get(f"session:{session_id}")
+        return json.loads(data) if data else []
+
+    def append(self, session_id: str, message: dict) -> None:
+        history = self.get(session_id)
+        history.append(message)
+        self.redis.set(f"session:{session_id}", json.dumps(history))

--- a/task_queue.py
+++ b/task_queue.py
@@ -1,0 +1,22 @@
+import json
+import redis
+from typing import Optional
+
+class TaskQueue:
+    """Simple FIFO queue backed by Redis."""
+
+    def __init__(self, redis_client=None, key: str = "task_queue"):
+        self.redis = redis_client or redis.Redis(host='localhost', port=6379, decode_responses=True)
+        self.key = key
+
+    def push(self, task: dict) -> None:
+        self.redis.lpush(self.key, json.dumps(task))
+
+    def pop(self, timeout: int = 0) -> Optional[dict]:
+        if timeout:
+            item = self.redis.brpop(self.key, timeout=timeout)
+            if item:
+                return json.loads(item[1])
+            return None
+        item = self.redis.rpop(self.key)
+        return json.loads(item) if item else None


### PR DESCRIPTION
## Summary
- add Redis-backed session manager and task queue
- implement simple Morpheus orchestrator with Neo and Trinity agents
- extend requirements with FastAPI, Redis, and Uvicorn

## Testing
- `python morpheus.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893f02f2be8832180eab5093ba1a186